### PR TITLE
use CMAKE_INSTALL_FULL_LIBDIR in pkgconfig instead of hardcoded lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(GNUInstallDirs)
 
 set(PREFIX ${CMAKE_INSTALL_PREFIX})
 set(INCLUDE ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+set(LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR})
 
 configure_file(hyprlang.pc.in hyprlang.pc @ONLY)
 

--- a/hyprlang.pc.in
+++ b/hyprlang.pc.in
@@ -1,6 +1,6 @@
 prefix=@PREFIX@
 includedir=@INCLUDE@
-libdir=${prefix}/lib
+libdir=@LIBDIR@
 
 Name: hyprlang
 URL: https://github.com/hyprwm/hyprlang


### PR DESCRIPTION
- use CMAKE_INSTALL_FULL_LIBDIR in pkgconfig instead of hardcoded lib
