### PR TITLE
Fix compilation and tests on 32bit architectures

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -175,7 +175,7 @@ static std::expected<int64_t, std::string> configStringToInt(const std::string& 
     if (VALUE.starts_with("0x")) {
         // Values with 0x are hex
         const auto VALUEWITHOUTHEX = VALUE.substr(2);
-        return stol(VALUEWITHOUTHEX, nullptr, 16);
+        return stoll(VALUEWITHOUTHEX, nullptr, 16);
     } else if (VALUE.starts_with("rgba(") && VALUE.ends_with(')')) {
         const auto VALUEWITHOUTFUNC = removeBeginEndSpacesTabs(VALUE.substr(5, VALUE.length() - 6));
 
@@ -199,7 +199,7 @@ static std::expected<int64_t, std::string> configStringToInt(const std::string& 
 
             return a * 0x1000000L + r.value() * 0x10000L + g.value() * 0x100L + b.value();
         } else if (VALUEWITHOUTFUNC.length() == 8) {
-            const auto RGBA = std::stol(VALUEWITHOUTFUNC, nullptr, 16);
+            const auto RGBA = std::stoll(VALUEWITHOUTFUNC, nullptr, 16);
 
             // now we need to RGBA -> ARGB. The config holds ARGB only.
             return (RGBA >> 8) + 0x1000000 * (RGBA & 0xFF);
@@ -225,7 +225,7 @@ static std::expected<int64_t, std::string> configStringToInt(const std::string& 
 
             return 0xFF000000L + r.value() * 0x10000L + g.value() * 0x100L + b.value();
         } else if (VALUEWITHOUTFUNC.length() == 6) {
-            const auto RGB = std::stol(VALUEWITHOUTFUNC, nullptr, 16);
+            const auto RGB = std::stoll(VALUEWITHOUTFUNC, nullptr, 16);
 
             return RGB + 0xFF000000;
         }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -197,7 +197,7 @@ static std::expected<int64_t, std::string> configStringToInt(const std::string& 
             if (!r.has_value() || !g.has_value() || !b.has_value())
                 return std::unexpected("failed parsing " + VALUEWITHOUTFUNC);
 
-            return a * INT64_C(0x1000000) + r.value() * INT64_C(0x10000) + g.value() * INT64_C(0x100) + b.value();
+            return a * (Hyprlang::INT)0x1000000 + r.value() * (Hyprlang::INT)0x10000 + g.value() * (Hyprlang::INT)0x100 + b.value();
         } else if (VALUEWITHOUTFUNC.length() == 8) {
             const auto RGBA = std::stoll(VALUEWITHOUTFUNC, nullptr, 16);
 
@@ -223,7 +223,7 @@ static std::expected<int64_t, std::string> configStringToInt(const std::string& 
             if (!r.has_value() || !g.has_value() || !b.has_value())
                 return std::unexpected("failed parsing " + VALUEWITHOUTFUNC);
 
-            return INT64_C(0xFF000000) + r.value() * INT64_C(0x10000) + g.value() * INT64_C(0x100) + b.value();
+            return (Hyprlang::INT)0xFF000000 + r.value() * (Hyprlang::INT)0x10000 + g.value() * (Hyprlang::INT)0x100 + b.value();
         } else if (VALUEWITHOUTFUNC.length() == 6) {
             const auto RGB = std::stoll(VALUEWITHOUTFUNC, nullptr, 16);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -197,7 +197,7 @@ static std::expected<int64_t, std::string> configStringToInt(const std::string& 
             if (!r.has_value() || !g.has_value() || !b.has_value())
                 return std::unexpected("failed parsing " + VALUEWITHOUTFUNC);
 
-            return a * 0x1000000L + r.value() * 0x10000L + g.value() * 0x100L + b.value();
+            return a * INT64_C(0x1000000) + r.value() * INT64_C(0x10000) + g.value() * INT64_C(0x100) + b.value();
         } else if (VALUEWITHOUTFUNC.length() == 8) {
             const auto RGBA = std::stoll(VALUEWITHOUTFUNC, nullptr, 16);
 
@@ -223,7 +223,7 @@ static std::expected<int64_t, std::string> configStringToInt(const std::string& 
             if (!r.has_value() || !g.has_value() || !b.has_value())
                 return std::unexpected("failed parsing " + VALUEWITHOUTFUNC);
 
-            return 0xFF000000L + r.value() * 0x10000L + g.value() * 0x100L + b.value();
+            return INT64_C(0xFF000000) + r.value() * INT64_C(0x10000) + g.value() * INT64_C(0x100) + b.value();
         } else if (VALUEWITHOUTFUNC.length() == 6) {
             const auto RGB = std::stoll(VALUEWITHOUTFUNC, nullptr, 16);
 

--- a/tests/fuzz/main.cpp
+++ b/tests/fuzz/main.cpp
@@ -20,7 +20,7 @@ std::string garbage() {
 int main(int argc, char** argv, char** envp) {
 
     Hyprlang::CConfig config("./eeeeeeeUnused", {.allowMissingConfig = true});
-    config.addConfigValue("test", {0L});
+    config.addConfigValue("test", {INT64_C(0)});
 
     config.parseDynamic("");
     config.parseDynamic("", "");

--- a/tests/fuzz/main.cpp
+++ b/tests/fuzz/main.cpp
@@ -20,7 +20,7 @@ std::string garbage() {
 int main(int argc, char** argv, char** envp) {
 
     Hyprlang::CConfig config("./eeeeeeeUnused", {.allowMissingConfig = true});
-    config.addConfigValue("test", {INT64_C(0)});
+    config.addConfigValue("test", {(Hyprlang::INT)0});
 
     config.parseDynamic("");
     config.parseDynamic("", "");

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -81,24 +81,24 @@ int main(int argc, char** argv, char** envp) {
         currentPath = std::filesystem::canonical("./config/");
 
         // setup config
-        config.addConfigValue("testInt", INT64_C(0));
+        config.addConfigValue("testInt", (Hyprlang::INT)0);
         config.addConfigValue("testFloat", 0.F);
         config.addConfigValue("testVec", Hyprlang::SVector2D{69, 420});
         config.addConfigValue("testString", "");
         config.addConfigValue("testEnv", "");
-        config.addConfigValue("testVar", INT64_C(0));
+        config.addConfigValue("testVar", (Hyprlang::INT)0);
         config.addConfigValue("testStringQuotes", "");
-        config.addConfigValue("testCategory:testValueInt", INT64_C(0));
-        config.addConfigValue("testCategory:testValueHex", INT64_C(0xA));
-        config.addConfigValue("testCategory:nested1:testValueNest", INT64_C(0));
-        config.addConfigValue("testCategory:nested1:nested2:testValueNest", INT64_C(0));
-        config.addConfigValue("testDefault", INT64_C(123));
-        config.addConfigValue("testCategory:testColor1", INT64_C(0));
-        config.addConfigValue("testCategory:testColor2", INT64_C(0));
-        config.addConfigValue("testCategory:testColor3", INT64_C(0));
-        config.addConfigValue("myColors:pink", INT64_C(0));
-        config.addConfigValue("myColors:green", INT64_C(0));
-        config.addConfigValue("myColors:random", INT64_C(0));
+        config.addConfigValue("testCategory:testValueInt", (Hyprlang::INT)0);
+        config.addConfigValue("testCategory:testValueHex", (Hyprlang::INT)0xA);
+        config.addConfigValue("testCategory:nested1:testValueNest", (Hyprlang::INT)0);
+        config.addConfigValue("testCategory:nested1:nested2:testValueNest", (Hyprlang::INT)0);
+        config.addConfigValue("testDefault", (Hyprlang::INT)123);
+        config.addConfigValue("testCategory:testColor1", (Hyprlang::INT)0);
+        config.addConfigValue("testCategory:testColor2", (Hyprlang::INT)0);
+        config.addConfigValue("testCategory:testColor3", (Hyprlang::INT)0);
+        config.addConfigValue("myColors:pink", (Hyprlang::INT)0);
+        config.addConfigValue("myColors:green", (Hyprlang::INT)0);
+        config.addConfigValue("myColors:random", (Hyprlang::INT)0);
         config.addConfigValue("customType", {Hyprlang::CConfigCustomValueType{&handleCustomValueSet, &handleCustomValueDestroy, "def"}});
 
         config.registerHandler(&handleDoABarrelRoll, "doABarrelRoll", {false});
@@ -106,16 +106,16 @@ int main(int argc, char** argv, char** envp) {
         config.registerHandler(&handleSource, "source", {false});
 
         config.addSpecialCategory("special", {"key"});
-        config.addSpecialConfigValue("special", "value", INT64_C(0));
+        config.addSpecialConfigValue("special", "value", (Hyprlang::INT)0);
 
         config.commence();
 
         config.addSpecialCategory("specialGeneric:one", {nullptr, true});
-        config.addSpecialConfigValue("specialGeneric:one", "value", INT64_C(0));
+        config.addSpecialConfigValue("specialGeneric:one", "value", (Hyprlang::INT)0);
         config.addSpecialCategory("specialGeneric:two", {nullptr, true});
-        config.addSpecialConfigValue("specialGeneric:two", "value", INT64_C(0));
+        config.addSpecialConfigValue("specialGeneric:two", "value", (Hyprlang::INT)0);
 
-        const Hyprlang::CConfigValue copyTest = {INT64_C(1)};
+        const Hyprlang::CConfigValue copyTest = {(Hyprlang::INT)1};
         config.addSpecialConfigValue("specialGeneric:one", "copyTest", copyTest);
 
         const auto PARSERESULT = config.parse();
@@ -134,14 +134,14 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(std::any_cast<Hyprlang::SVector2D>(config.getConfigValue("testVec")), EXP);
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testString")), std::string{"Hello World! # This is not a comment!"});
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testStringQuotes")), std::string{"\"Hello World!\""});
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueInt")), INT64_C(123456));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), INT64_C(0xFFFFAABB));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:testValueNest")), INT64_C(1));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:nested2:testValueNest")), INT64_C(1));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testDefault")), INT64_C(123));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor1")), INT64_C(0xFFFFFFFF));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor2")), INT64_C(0xFF000000));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor3")), INT64_C(0x22ffeeff));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueInt")), (Hyprlang::INT)123456);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), (Hyprlang::INT)0xFFFFAABB);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:testValueNest")), (Hyprlang::INT)1);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:nested2:testValueNest")), (Hyprlang::INT)1);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testDefault")), (Hyprlang::INT)123);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor1")), (Hyprlang::INT)0xFFFFFFFF);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor2")), (Hyprlang::INT)0xFF000000);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor3")), (Hyprlang::INT)0x22ffeeff);
 
         // test static values
         std::cout << " → Testing static values\n";
@@ -161,7 +161,7 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(config.parseDynamic("doABarrelRoll = woohoo, some, params").error, false);
         EXPECT(barrelRoll, true);
         EXPECT(config.parseDynamic("testCategory:testValueHex", "0xaabbccdd").error, false);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), INT64_C(0xAABBCCDD));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), (Hyprlang::INT)0xAABBCCDD);
 
         // test variables
         std::cout << " → Testing variables\n";
@@ -188,13 +188,13 @@ int main(int argc, char** argv, char** envp) {
 
         // test sourcing
         std::cout << " → Testing sourcing\n";
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:pink")), INT64_C(0xFFc800c8));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:green")), INT64_C(0xFF14f014));
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:random")), INT64_C(0xFFFF1337));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:pink")), (Hyprlang::INT)0xFFc800c8);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:green")), (Hyprlang::INT)0xFF14f014);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:random")), (Hyprlang::INT)0xFFFF1337);
 
         // test custom type
         std::cout << " → Testing custom types\n";
-        EXPECT(*reinterpret_cast<int64_t*>(std::any_cast<void*>(config.getConfigValue("customType"))), INT64_C(1));
+        EXPECT(*reinterpret_cast<int64_t*>(std::any_cast<void*>(config.getConfigValue("customType"))), (Hyprlang::INT)1);
 
         std::cout << " → Testing error.conf\n";
         Hyprlang::CConfig errorConfig("./config/error.conf", {.verifyOnly = true, .throwAllErrors = true});

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -81,24 +81,24 @@ int main(int argc, char** argv, char** envp) {
         currentPath = std::filesystem::canonical("./config/");
 
         // setup config
-        config.addConfigValue("testInt", 0L);
+        config.addConfigValue("testInt", INT64_C(0));
         config.addConfigValue("testFloat", 0.F);
         config.addConfigValue("testVec", Hyprlang::SVector2D{69, 420});
         config.addConfigValue("testString", "");
         config.addConfigValue("testEnv", "");
-        config.addConfigValue("testVar", 0L);
+        config.addConfigValue("testVar", INT64_C(0));
         config.addConfigValue("testStringQuotes", "");
-        config.addConfigValue("testCategory:testValueInt", 0L);
-        config.addConfigValue("testCategory:testValueHex", 0xAL);
-        config.addConfigValue("testCategory:nested1:testValueNest", 0L);
-        config.addConfigValue("testCategory:nested1:nested2:testValueNest", 0L);
-        config.addConfigValue("testDefault", 123L);
-        config.addConfigValue("testCategory:testColor1", 0L);
-        config.addConfigValue("testCategory:testColor2", 0L);
-        config.addConfigValue("testCategory:testColor3", 0L);
-        config.addConfigValue("myColors:pink", 0L);
-        config.addConfigValue("myColors:green", 0L);
-        config.addConfigValue("myColors:random", 0L);
+        config.addConfigValue("testCategory:testValueInt", INT64_C(0));
+        config.addConfigValue("testCategory:testValueHex", INT64_C(0xA));
+        config.addConfigValue("testCategory:nested1:testValueNest", INT64_C(0));
+        config.addConfigValue("testCategory:nested1:nested2:testValueNest", INT64_C(0));
+        config.addConfigValue("testDefault", INT64_C(123));
+        config.addConfigValue("testCategory:testColor1", INT64_C(0));
+        config.addConfigValue("testCategory:testColor2", INT64_C(0));
+        config.addConfigValue("testCategory:testColor3", INT64_C(0));
+        config.addConfigValue("myColors:pink", INT64_C(0));
+        config.addConfigValue("myColors:green", INT64_C(0));
+        config.addConfigValue("myColors:random", INT64_C(0));
         config.addConfigValue("customType", {Hyprlang::CConfigCustomValueType{&handleCustomValueSet, &handleCustomValueDestroy, "def"}});
 
         config.registerHandler(&handleDoABarrelRoll, "doABarrelRoll", {false});
@@ -106,16 +106,16 @@ int main(int argc, char** argv, char** envp) {
         config.registerHandler(&handleSource, "source", {false});
 
         config.addSpecialCategory("special", {"key"});
-        config.addSpecialConfigValue("special", "value", 0L);
+        config.addSpecialConfigValue("special", "value", INT64_C(0));
 
         config.commence();
 
         config.addSpecialCategory("specialGeneric:one", {nullptr, true});
-        config.addSpecialConfigValue("specialGeneric:one", "value", 0L);
+        config.addSpecialConfigValue("specialGeneric:one", "value", INT64_C(0));
         config.addSpecialCategory("specialGeneric:two", {nullptr, true});
-        config.addSpecialConfigValue("specialGeneric:two", "value", 0L);
+        config.addSpecialConfigValue("specialGeneric:two", "value", INT64_C(0));
 
-        const Hyprlang::CConfigValue copyTest = {1L};
+        const Hyprlang::CConfigValue copyTest = {INT64_C(1)};
         config.addSpecialConfigValue("specialGeneric:one", "copyTest", copyTest);
 
         const auto PARSERESULT = config.parse();
@@ -134,14 +134,14 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(std::any_cast<Hyprlang::SVector2D>(config.getConfigValue("testVec")), EXP);
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testString")), std::string{"Hello World! # This is not a comment!"});
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testStringQuotes")), std::string{"\"Hello World!\""});
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueInt")), 123456L);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), 0xFFFFAABBL);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:testValueNest")), 1L);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:nested2:testValueNest")), 1L);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testDefault")), 123L);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor1")), 0xFFFFFFFFL);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor2")), 0xFF000000L);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor3")), 0x22ffeeffL);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueInt")), INT64_C(123456));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), INT64_C(0xFFFFAABB));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:testValueNest")), INT64_C(1));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:nested1:nested2:testValueNest")), INT64_C(1));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testDefault")), INT64_C(123));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor1")), INT64_C(0xFFFFFFFF));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor2")), INT64_C(0xFF000000));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor3")), INT64_C(0x22ffeeff));
 
         // test static values
         std::cout << " → Testing static values\n";
@@ -161,7 +161,7 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(config.parseDynamic("doABarrelRoll = woohoo, some, params").error, false);
         EXPECT(barrelRoll, true);
         EXPECT(config.parseDynamic("testCategory:testValueHex", "0xaabbccdd").error, false);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), 0xAABBCCDDL);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testValueHex")), INT64_C(0xAABBCCDD));
 
         // test variables
         std::cout << " → Testing variables\n";
@@ -188,13 +188,13 @@ int main(int argc, char** argv, char** envp) {
 
         // test sourcing
         std::cout << " → Testing sourcing\n";
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:pink")), 0xFFc800c8L);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:green")), 0xFF14f014L);
-        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:random")), 0xFFFF1337L);
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:pink")), INT64_C(0xFFc800c8));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:green")), INT64_C(0xFF14f014));
+        EXPECT(std::any_cast<int64_t>(config.getConfigValue("myColors:random")), INT64_C(0xFFFF1337));
 
         // test custom type
         std::cout << " → Testing custom types\n";
-        EXPECT(*reinterpret_cast<int64_t*>(std::any_cast<void*>(config.getConfigValue("customType"))), 1L);
+        EXPECT(*reinterpret_cast<int64_t*>(std::any_cast<void*>(config.getConfigValue("customType"))), INT64_C(1));
 
         std::cout << " → Testing error.conf\n";
         Hyprlang::CConfig errorConfig("./config/error.conf", {.verifyOnly = true, .throwAllErrors = true});


### PR DESCRIPTION
On 32-bit systems, 'long' is only 32 bits (and 'long long' is 64 bits).

* Using the L suffix for long was switched to ~~the INT64_C macro: see https://stackoverflow.com/questions/65406823/is-there-a-portable-literal-suffix-for-int64-t-and-similar-types~~ to an explicit cast to Hyprlang::INT.
* calls to `stol` were switched to `stoll` to fix them (in theory, it would be better to but this in an `#ifdef` to use `stol` on 64 bit systems, and `stoll` on 32 bit systems, but it doesn't seem to hurt the 64-bit systems)