### PR TITLE
Fix the overlay and re-export properly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,10 @@
   }: let
     inherit (nixpkgs) lib;
     eachSystem = lib.genAttrs (import systems);
-    pkgsFor = nixpkgs.legacyPackages;
+    pkgsFor = eachSystem (system:
+      import nixpkgs {
+        localSystem.system = system;
+      });
     mkDate = longDate: (lib.concatStringsSep "-" [
       (builtins.substring 0 4 longDate)
       (builtins.substring 4 2 longDate)

--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,12 @@
   in {
     overlays = {
       default = self.overlays.hyprlang;
-      hyprlang = _: prev: rec {
+      hyprlang = final: prev: {
         hyprlang = prev.callPackage ./nix/default.nix {
           stdenv = prev.gcc13Stdenv;
           version = "0.pre" + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
         };
-        hyprlang-with-tests = hyprlang.override {doCheck = true;};
+        hyprlang-with-tests = final.hyprlang.override {doCheck = true;};
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,15 @@
       (builtins.substring 6 2 longDate)
     ]);
   in {
-    overlays.default = _: prev: rec {
-      hyprlang = prev.callPackage ./nix/default.nix {
-        stdenv = prev.gcc13Stdenv;
-        version = "0.pre" + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
+    overlays = {
+      default = self.overlays.hyprlang;
+      hyprlang = _: prev: rec {
+        hyprlang = prev.callPackage ./nix/default.nix {
+          stdenv = prev.gcc13Stdenv;
+          version = "0.pre" + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
+        };
+        hyprlang-with-tests = hyprlang.override {doCheck = true;};
       };
-      hyprlang-with-tests = hyprlang.override {doCheck = true;};
     };
 
     packages = eachSystem (system:

--- a/flake.nix
+++ b/flake.nix
@@ -26,8 +26,8 @@
     overlays = {
       default = self.overlays.hyprlang;
       hyprlang = final: prev: {
-        hyprlang = prev.callPackage ./nix/default.nix {
-          stdenv = prev.gcc13Stdenv;
+        hyprlang = final.callPackage ./nix/default.nix {
+          stdenv = final.gcc13Stdenv;
           version = "0.pre" + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
         };
         hyprlang-with-tests = final.hyprlang.override {doCheck = true;};

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
     pkgsFor = eachSystem (system:
       import nixpkgs {
         localSystem.system = system;
+        overlays = with self.overlays; [hyprlang];
       });
     mkDate = longDate: (lib.concatStringsSep "-" [
       (builtins.substring 0 4 longDate)
@@ -34,9 +35,10 @@
       };
     };
 
-    packages = eachSystem (system:
-      (self.overlays.default null pkgsFor.${system})
-      // {default = self.packages.${system}.hyprlang;});
+    packages = eachSystem (system: {
+      default = self.packages.${system}.hyprlang;
+      inherit (pkgsFor.${system}) hyprlang hyprlang-with-tests;
+    });
 
     formatter = eachSystem (system: pkgsFor.${system}.alejandra);
   };


### PR DESCRIPTION
Haha, here I come again, to fix your Nix. Enjoy not having infinite recursion bugs, *and* exporting packages from the evaluated overlay properly!

This PR brings this flake in line (in semantics, function, and style) with the other three (`hyprland`, `hyprland-xdph`, and `hyprland-protocols`).

@fufexan Have you learned *nothing* from me!?