### PR TITLE
config.cpp: fix environ for Apple

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -10,7 +10,13 @@
 #include <cstring>
 
 using namespace Hyprlang;
+
+#ifdef __APPLE__
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#else
 extern "C" char** environ;
+#endif
 
 // defines
 inline constexpr const char* ANONYMOUS_KEY = "__hyprlang_internal_anonymous_key";


### PR DESCRIPTION
Fix build error on macOS.

P. S. Test run on 10.6 ppc and 14.4 arm64, everything passes.