### PR TITLE
Fix: Comment escaping with multiple `#`

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -31,27 +31,6 @@ static size_t seekABIStructSize(const void* begin, size_t startOffset, size_t ma
     return 0;
 }
 
-static std::string removeBeginSpacesTabs(const std::string& str) {
-    if (str.empty())
-        return str;
-
-    size_t firstNonSpaceTab = str.find_first_not_of(" \t");
-
-    return str.substr(firstNonSpaceTab, str.length() - firstNonSpaceTab);
-}
-
-static std::string removeEndSpacesTabs(const std::string& str) {
-    if (str.empty())
-        return str;
-
-    size_t lastNonSpaceTab = str.find_last_not_of(" \t");
-
-    if (lastNonSpaceTab == std::string::npos)
-        return str;
-
-    return str.substr(0, lastNonSpaceTab + 1);
-}
-
 static std::string removeBeginEndSpacesTabs(std::string str) {
     if (str.empty())
         return str;
@@ -504,7 +483,7 @@ CParseResult CConfig::parseVariable(const std::string& lhs, const std::string& r
 CParseResult CConfig::parseLine(std::string line, bool dynamic) {
     CParseResult result;
 
-    line = removeBeginSpacesTabs(line);
+    line = removeBeginEndSpacesTabs(line);
 
     auto   commentPos  = line.find('#');
     size_t lastHashPos = 0;
@@ -527,7 +506,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
         }
     }
 
-    line = removeEndSpacesTabs(line);
+    line = removeBeginEndSpacesTabs(line);
 
     auto equalsPos = line.find('=');
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -485,12 +485,16 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
 
     line = removeBeginEndSpacesTabs(line);
 
-    auto   commentPos  = line.find('#');
+    auto commentPos = line.find('#');
+
+    if (commentPos == 0)
+        return result;
+
     size_t lastHashPos = 0;
 
     while (commentPos != std::string::npos) {
         bool escaped = false;
-        if (commentPos < line.length() - 1 && commentPos != 0) {
+        if (commentPos < line.length() - 1) {
             if (line[commentPos + 1] == '#') {
                 lastHashPos = commentPos + 2;
                 escaped     = true;
@@ -508,9 +512,12 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
 
     line = removeBeginEndSpacesTabs(line);
 
+    if (line.empty())
+        return result;
+
     auto equalsPos = line.find('=');
 
-    if (equalsPos == std::string::npos && !line.ends_with("{") && line != "}" && !line.empty()) {
+    if (equalsPos == std::string::npos && !line.ends_with("{") && line != "}") {
         // invalid line
         result.setError("Invalid config line");
         return result;
@@ -579,7 +586,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
 
         if (ret.error)
             return ret;
-    } else if (!line.empty()) {
+    } else {
         // has to be a set
         if (line.contains("}")) {
             // easiest. } or invalid.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -31,6 +31,27 @@ static size_t seekABIStructSize(const void* begin, size_t startOffset, size_t ma
     return 0;
 }
 
+static std::string removeBeginSpacesTabs(const std::string& str) {
+    if (str.empty())
+        return str;
+
+    size_t firstNonSpaceTab = str.find_first_not_of(" \t");
+
+    return str.substr(firstNonSpaceTab, str.length() - firstNonSpaceTab);
+}
+
+static std::string removeEndSpacesTabs(const std::string& str) {
+    if (str.empty())
+        return str;
+
+    size_t lastNonSpaceTab = str.find_last_not_of(" \t");
+
+    if (lastNonSpaceTab == std::string::npos)
+        return str;
+
+    return str.substr(0, lastNonSpaceTab + 1);
+}
+
 static std::string removeBeginEndSpacesTabs(std::string str) {
     if (str.empty())
         return str;
@@ -483,12 +504,14 @@ CParseResult CConfig::parseVariable(const std::string& lhs, const std::string& r
 CParseResult CConfig::parseLine(std::string line, bool dynamic) {
     CParseResult result;
 
-    auto         commentPos  = line.find('#');
-    size_t       lastHashPos = 0;
+    line = removeBeginSpacesTabs(line);
+
+    auto   commentPos  = line.find('#');
+    size_t lastHashPos = 0;
 
     while (commentPos != std::string::npos) {
         bool escaped = false;
-        if (commentPos < line.length() - 1) {
+        if (commentPos < line.length() - 1 && commentPos != 0) {
             if (line[commentPos + 1] == '#') {
                 lastHashPos = commentPos + 2;
                 escaped     = true;
@@ -504,7 +527,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
         }
     }
 
-    line = removeBeginEndSpacesTabs(line);
+    line = removeEndSpacesTabs(line);
 
     auto equalsPos = line.find('=');
 

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -1,5 +1,10 @@
 
 # Test comment
+## This is also a comment
+ ## This is a comment with space as a first character
+	## This is a comment with tab as a first character
+  	  	## This is a comment with leading spaces and tabs
+ ##### Comment with more hash tags
 
 testInt = 123
 testFloat = 123.456


### PR DESCRIPTION
This PR fixes #30 

Meaning that this:

```
  	  	##### This is a comment with leading spaces and tabs
```

is now a valid config comment and the whole line (in this case) would be ignored.