### PR TITLE
Fixed getconf command in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's user-friendly, easy to grasp, and easy to implement.
 Building is done via CMake:
 ```sh
 cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -S . -B ./build
-cmake --build ./build --config Release --target hyprlang -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+cmake --build ./build --config Release --target hyprlang -j`nproc 2>/dev/null || getconf _NPROCESSORS_CONF`
 ```
 Install with:
 ```sh


### PR DESCRIPTION
getconf NPROCESSORS_CONF isn't a valid command. The correct command is getconf _NPROCESSORS_CONF.