### PR TITLE
core: handle scoped keywords if flags are not allowed

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -563,9 +563,30 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
             return parseVariable(LHS, RHS, dynamic);
 
         bool found = false;
+
         for (auto& h : impl->handlers) {
-            if (!h.options.allowFlags && h.name != LHS)
-                continue;
+            if (!h.options.allowFlags) {
+                // we want to handle potentially nested keywords and ensure
+                // we only call the handler if they are scoped correctly.
+                size_t colon = 0;
+                size_t idx   = 0;
+                size_t depth = 0;
+
+                while ((colon = h.name.find(":", idx)) != std::string::npos && impl->categories.size() > depth) {
+                    auto actual = h.name.substr(idx, colon - idx);
+
+                    if (actual != impl->categories[depth]) {
+                        break;
+                    }
+
+                    idx = colon + 1;
+                    ++depth;
+                }
+
+                if (depth != impl->categories.size() || h.name.substr(idx) != LHS) {
+                    continue;
+                }
+            }
 
             if (h.options.allowFlags && (!LHS.starts_with(h.name) || LHS.contains(':') /* avoid cases where a category is called the same as a handler */))
                 continue;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -575,17 +575,15 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                 while ((colon = h.name.find(":", idx)) != std::string::npos && impl->categories.size() > depth) {
                     auto actual = h.name.substr(idx, colon - idx);
 
-                    if (actual != impl->categories[depth]) {
+                    if (actual != impl->categories[depth])
                         break;
-                    }
 
                     idx = colon + 1;
                     ++depth;
                 }
 
-                if (depth != impl->categories.size() || h.name.substr(idx) != LHS) {
+                if (depth != impl->categories.size() || h.name.substr(idx) != LHS)
                     continue;
-                }
             }
 
             if (h.options.allowFlags && (!LHS.starts_with(h.name) || LHS.contains(':') /* avoid cases where a category is called the same as a handler */))

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -28,6 +28,8 @@ errorVariable = true
 
 # hyprlang noerror false
 
+categoryKeyword = oops, this one shouldn't call the handler, not fun
+
 testCategory {
     testValueInt = 123456
     testValueHex = 0xF
@@ -40,14 +42,20 @@ testCategory {
         testValueNest = 1
         nested2 {
             testValueNest = 1
-        }
-    }
+    	}
+		categoryKeyword = this one should not either
+	}
+
+	categoryKeyword = we are having fun
+	categoryKeyword = so much fun
+	categoryKeyword = im the fun one at parties
 }
+
 
 $SPECIALVAL1 = 1
 
 special {
-    key = a
+	key = a
     value = $SPECIALVAL1
 }
 

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -42,20 +42,19 @@ testCategory {
         testValueNest = 1
         nested2 {
             testValueNest = 1
-    	}
-		categoryKeyword = this one should not either
-	}
+        }
+        categoryKeyword = this one should not either
+    }
 
-	categoryKeyword = we are having fun
-	categoryKeyword = so much fun
-	categoryKeyword = im the fun one at parties
+    categoryKeyword = we are having fun
+    categoryKeyword = so much fun
+    categoryKeyword = im the fun one at parties
 }
-
 
 $SPECIALVAL1 = 1
 
 special {
-	key = a
+    key = a
     value = $SPECIALVAL1
 }
 

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -159,6 +159,8 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor2")), (Hyprlang::INT)0xFF000000);
         EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor3")), (Hyprlang::INT)0x22ffeeff);
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testStringColon")), std::string{"ee:ee:ee"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("categoryKeyword")), std::string{"oops, this one shouldn't call the handler, not fun"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testCategory:nested1:categoryKeyword")), std::string{"this one should not either"});
 
         // test static values
         std::cout << " → Testing static values\n";

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -23,12 +23,13 @@ namespace Colors {
     }
 
 // globals for testing
-bool                          barrelRoll  = false;
-std::string                   flagsFound  = "";
-Hyprlang::CConfig*            pConfig     = nullptr;
-std::string                   currentPath = "";
+bool                            barrelRoll  = false;
+std::string                     flagsFound  = "";
+Hyprlang::CConfig*              pConfig     = nullptr;
+std::string                     currentPath = "";
+static std::vector<std::string> categoryKeywordActualValues;
 
-static Hyprlang::CParseResult handleDoABarrelRoll(const char* COMMAND, const char* VALUE) {
+static Hyprlang::CParseResult   handleDoABarrelRoll(const char* COMMAND, const char* VALUE) {
     if (std::string(VALUE) == "woohoo, some, params")
         barrelRoll = true;
 
@@ -42,6 +43,12 @@ static Hyprlang::CParseResult handleFlagsTest(const char* COMMAND, const char* V
 
     Hyprlang::CParseResult result;
     return result;
+}
+
+static Hyprlang::CParseResult handleCategoryKeyword(const char* COMMAND, const char* VALUE) {
+    categoryKeywordActualValues.push_back(VALUE);
+
+    return Hyprlang::CParseResult();
 }
 
 static Hyprlang::CParseResult handleSource(const char* COMMAND, const char* VALUE) {
@@ -88,12 +95,14 @@ int main(int argc, char** argv, char** envp) {
         config.addConfigValue("testStringColon", "");
         config.addConfigValue("testEnv", "");
         config.addConfigValue("testVar", (Hyprlang::INT)0);
+        config.addConfigValue("categoryKeyword", (Hyprlang::STRING) "");
         config.addConfigValue("testStringQuotes", "");
         config.addConfigValue("testStringRecursive", "");
         config.addConfigValue("testCategory:testValueInt", (Hyprlang::INT)0);
         config.addConfigValue("testCategory:testValueHex", (Hyprlang::INT)0xA);
         config.addConfigValue("testCategory:nested1:testValueNest", (Hyprlang::INT)0);
         config.addConfigValue("testCategory:nested1:nested2:testValueNest", (Hyprlang::INT)0);
+        config.addConfigValue("testCategory:nested1:categoryKeyword", (Hyprlang::STRING) "");
         config.addConfigValue("testDefault", (Hyprlang::INT)123);
         config.addConfigValue("testCategory:testColor1", (Hyprlang::INT)0);
         config.addConfigValue("testCategory:testColor2", (Hyprlang::INT)0);
@@ -107,6 +116,7 @@ int main(int argc, char** argv, char** envp) {
         config.registerHandler(&handleDoABarrelRoll, "doABarrelRoll", {false});
         config.registerHandler(&handleFlagsTest, "flags", {true});
         config.registerHandler(&handleSource, "source", {false});
+        config.registerHandler(&handleCategoryKeyword, "testCategory:categoryKeyword", {false});
 
         config.addSpecialCategory("special", {"key"});
         config.addSpecialConfigValue("special", "value", (Hyprlang::INT)0);
@@ -161,6 +171,10 @@ int main(int argc, char** argv, char** envp) {
         std::cout << " → Testing handlers\n";
         EXPECT(barrelRoll, true);
         EXPECT(flagsFound, std::string{"abc"});
+
+        EXPECT(categoryKeywordActualValues[0], "we are having fun");
+        EXPECT(categoryKeywordActualValues[1], "so much fun");
+        EXPECT(categoryKeywordActualValues[2], "im the fun one at parties");
 
         // test dynamic
         std::cout << " → Testing dynamic\n";

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -174,9 +174,9 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(barrelRoll, true);
         EXPECT(flagsFound, std::string{"abc"});
 
-        EXPECT(categoryKeywordActualValues[0], "we are having fun");
-        EXPECT(categoryKeywordActualValues[1], "so much fun");
-        EXPECT(categoryKeywordActualValues[2], "im the fun one at parties");
+        EXPECT(categoryKeywordActualValues.at(0), "we are having fun");
+        EXPECT(categoryKeywordActualValues.at(1), "so much fun");
+        EXPECT(categoryKeywordActualValues.at(2), "im the fun one at parties");
 
         // test dynamic
         std::cout << " → Testing dynamic\n";


### PR DESCRIPTION
I was playing with Hyprlang to handle configuration for a project of mine and found out that keywords inside categories are not properly handled (they are simply being ignored).

I added tests to make sure only the correctly scoped keywords are calling the handler.