### PR TITLE
feat: use std::function instead of C-style fptr

### DIFF
--- a/include/hyprlang.hpp
+++ b/include/hyprlang.hpp
@@ -6,6 +6,7 @@
 #include <any>
 #include <memory>
 #include <string>
+#include <functional>
 #include <fstream>
 #include <vector>
 
@@ -168,7 +169,7 @@ namespace Hyprlang {
     /*!
         typedefs
     */
-    typedef CParseResult (*PCONFIGHANDLERFUNC)(const char* COMMAND, const char* VALUE);
+    typedef std::function<CParseResult(const char*, const char*)> PCONFIGHANDLERFUNC;
     typedef CParseResult (*PCONFIGCUSTOMVALUEHANDLERFUNC)(const char* VALUE, void** data);
     typedef void (*PCONFIGCUSTOMVALUEDESTRUCTOR)(void** data);
 

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -44,6 +44,8 @@ testCategory {
     }
 }
 
+lambaCapture = 1
+
 $SPECIALVAL1 = 1
 
 special {

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -108,6 +108,16 @@ int main(int argc, char** argv, char** envp) {
         config.registerHandler(&handleFlagsTest, "flags", {true});
         config.registerHandler(&handleSource, "source", {false});
 
+        bool lambaCaptureFlag = false;
+
+        config.registerHandler(
+            [&lambaCaptureFlag](const char* name, const char* value) {
+                lambaCaptureFlag = true;
+
+                return Hyprlang::CParseResult();
+            },
+            "lambaCapture", {false});
+
         config.addSpecialCategory("special", {"key"});
         config.addSpecialConfigValue("special", "value", (Hyprlang::INT)0);
 
@@ -161,6 +171,7 @@ int main(int argc, char** argv, char** envp) {
         std::cout << " → Testing handlers\n";
         EXPECT(barrelRoll, true);
         EXPECT(flagsFound, std::string{"abc"});
+        EXPECT(lambaCaptureFlag, true);
 
         // test dynamic
         std::cout << " → Testing dynamic\n";


### PR DESCRIPTION
Keyword handlers currently rely on C-style function pointers which have several caveats, one of them being that they are unable to work with lambda capture groups, making it hard to change program state that is not global, especially since the callback doesn't accept a `data` argument as a `void*` or something of that nature.

Unless there is a major reason not to I think it's better to use a `std::function` instead. The only thing that comes to mind is ABI compatiblity but I'm pretty sure this is not a concern here, let me know what you think.

If that's accepted we might want to change the other function pointers to use `std::function` as well, I only did that one because it's very cumbersome to use without.

See test case for usage example.