### PR TITLE
feat: implement multiline support

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -572,6 +572,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
         bool isMultilineContinuation = lastChar == '\\' || lastChar == '>';
 
         if (isMultilineContinuation && impl->multiline.active && impl->multiline.delimiter != lastChar) {
+            impl->multiline.active = false;
             result.setError("Multiline continuation character mismatch. Make sure you are not mixing \\ and >");
 
             return result;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -35,7 +35,7 @@ enum eDataType {
     CONFIGDATATYPE_CUSTOM,
 };
 
-struct SMultiLine {
+struct SMultiline {
     std::string buffer;
     char        delimiter = 0;
     bool        active    = false;
@@ -93,7 +93,7 @@ class CConfigImpl {
     std::string                                              currentSpecialKey      = "";
     SSpecialCategory*                                        currentSpecialCategory = nullptr; // if applicable
     bool                                                     isSpecialCategory      = false;
-    SMultiLine                                               multiline;
+    SMultiline                                               multiline;
 
     std::string                                              parseError = "";
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+static const char* MULTILINE_SPACE_CHARSET = " \t";
+
 struct SHandler {
     std::string                  name = "";
     Hyprlang::SHandlerOptions    options;
@@ -31,6 +33,13 @@ enum eDataType {
     CONFIGDATATYPE_STR,
     CONFIGDATATYPE_VEC2,
     CONFIGDATATYPE_CUSTOM,
+};
+
+struct SMultiLine {
+    std::string buffer;
+    char        delimiter = 0;
+    bool        active    = false;
+    std::string lhs;
 };
 
 // CUSTOM is stored as STR!!
@@ -83,6 +92,8 @@ class CConfigImpl {
     std::vector<std::string>                                 categories;
     std::string                                              currentSpecialKey      = "";
     SSpecialCategory*                                        currentSpecialCategory = nullptr; // if applicable
+    bool                                                     isSpecialCategory      = false;
+    SMultiLine                                               multiline;
 
     std::string                                              parseError = "";
 

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -79,6 +79,51 @@ flagsStuff {
     value = 2
 }
 
+
+# '\' POSIX shell-like multiline syntax
+# Leading spaces are preserved while trailing spaces and linebreaks are discarded
+multilineSimple = I use C++ because \
+    I hate Java
+
+multilineTrim = I use Javascript because    \ # Spaces should be trimmed before and after the delimiter
+    I hate Python          # here also.
+
+multilineVar = $SPECIALVAL1	\
+ $SPECIALVAL1				\
+  $SPECIALVAL1				\
+   $SPECIALVAL1
+
+$NAME = multiline
+
+multilineBreakWord = Hello $NAME, how are you to\
+day?
+
+multilineMultiBreakWord = oui   \
+ oui                            \
+ b                              \
+a                               \
+g                               \
+u                               \
+e                               \
+t                               \
+t                               \
+e
+
+# Another syntax for multiline.
+# Ignores leading and trailing whitespaces. Linebreaks are turned into spaces. 
+
+multilineCategory {
+    indentedMultiline = Hello                           >
+                        world                           >
+                        this is another syntax for      >
+                        multiline that trims all spaces
+
+    multilineUneven = Hello                           >
+        world                           >
+            this is another syntax for      >
+                multiline that trims all spaces
+}
+
 testCategory:testValueHex = 0xFFfFaAbB
 
 $RECURSIVE1 = a

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -103,6 +103,14 @@ int main(int argc, char** argv, char** envp) {
         config.addConfigValue("myColors:green", (Hyprlang::INT)0);
         config.addConfigValue("myColors:random", (Hyprlang::INT)0);
         config.addConfigValue("customType", {Hyprlang::CConfigCustomValueType{&handleCustomValueSet, &handleCustomValueDestroy, "def"}});
+        config.addConfigValue("multilineSimple", (Hyprlang::STRING) "");
+        config.addConfigValue("multilineTrim", (Hyprlang::STRING) "");
+        config.addConfigValue("multilineVar", (Hyprlang::STRING) "");
+        config.addConfigValue("multilineTrim", (Hyprlang::STRING) "");
+        config.addConfigValue("multilineBreakWord", (Hyprlang::STRING) "");
+        config.addConfigValue("multilineMultiBreakWord", (Hyprlang::STRING) "");
+        config.addConfigValue("multilineCategory:indentedMultiline", (Hyprlang::STRING) "");
+        config.addConfigValue("multilineCategory:multilineUneven", (Hyprlang::STRING) "");
 
         config.registerHandler(&handleDoABarrelRoll, "doABarrelRoll", {false});
         config.registerHandler(&handleFlagsTest, "flags", {true});
@@ -149,6 +157,15 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor2")), (Hyprlang::INT)0xFF000000);
         EXPECT(std::any_cast<int64_t>(config.getConfigValue("testCategory:testColor3")), (Hyprlang::INT)0x22ffeeff);
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testStringColon")), std::string{"ee:ee:ee"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("multilineSimple")), std::string{"I use C++ because    I hate Java"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("multilineTrim")), std::string{"I use Javascript because    I hate Python"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("multilineVar")), std::string{"1 1  1   1"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("multilineBreakWord")), std::string{"Hello multiline, how are you today?"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("multilineMultiBreakWord")), std::string{"oui oui baguette"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("multilineCategory:indentedMultiline")),
+               std::string{"Hello world this is another syntax for multiline that trims all spaces"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("multilineCategory:multilineUneven")),
+               std::string{"Hello world this is another syntax for multiline that trims all spaces"});
 
         // test static values
         std::cout << " → Testing static values\n";


### PR DESCRIPTION
Last one I swear, but I need this xD

This implements multi line support through two different delimiters

- `\` is used a posix shell-like multi line delimiter, it preserves leading spaces and trims trailing ones. Line breaks are ignored.  
- `>` ignores all space characters, allowing for arbitrary indentation. Line breaks are replaced by a single space.

See example config and test cases for actual examples :)