### PR TITLE
CMake: Use library aliases instead of library names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,13 +56,14 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   message(STATUS "Using clang++ to compile hyprlang")
 endif()
 
+add_library(hypr::hyprlang ALIAS hyprlang)
 install(TARGETS hyprlang)
 
 # tests
 add_custom_target(tests)
 
 add_executable(hyprlang_test "tests/parse/main.cpp")
-target_link_libraries(hyprlang_test PRIVATE hyprlang hyprutils)
+target_link_libraries(hyprlang_test PRIVATE hypr::hyprlang)
 add_test(
   NAME "Parsing"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
@@ -70,7 +71,7 @@ add_test(
 add_dependencies(tests hyprlang_test)
 
 add_executable(hyprlang_fuzz "tests/fuzz/main.cpp")
-target_link_libraries(hyprlang_fuzz PRIVATE hyprlang hyprutils)
+target_link_libraries(hyprlang_fuzz PRIVATE hypr::hyprlang)
 add_test(
   NAME "Fuzz"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests


### PR DESCRIPTION
This changeset makes it possible to compile hyprlang with a custom install prefix, which was not honored because of using "hyprutils" as a raw dependency, which means that CMake was adding "-lhyprutils" flag to the linker, but the linker didn't know the path in case a custom install prefix was used to compile hyprutils.