### PR TITLE
Add ability to escape {{EXPRESSION}} syntax from #75

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,5 @@
 #include "config.hpp"
+#include <array>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -698,8 +699,8 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
 
         // Removing escape chars. -- in the future, maybe map all the chars that can be escaped.
         // Right now only expression parsing has escapeable chars
-        const char ESCAPE_CHAR = '\\';
-        const char ESCAPE_SET[]{'{', '}'};
+        const char                ESCAPE_CHAR = '\\';
+        const std::array<char, 2> ESCAPE_SET{'{', '}'};
         for (long i = 0; i < (long)RHS.length() - (long)1; i++) {
             if (RHS.at(i) != ESCAPE_CHAR)
                 continue;
@@ -709,7 +710,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                 continue;
             }
             //checks if any of the chars were escapable.
-            for (unsigned int j = 0; j < sizeof(ESCAPE_SET) / sizeof(char); j++) {
+            for (unsigned int j = 0; j < ESCAPE_SET.size(); j++) {
                 if (RHS.at(i + 1) == ESCAPE_SET[j]) {
                     RHS.erase(i--, 1);
                     break;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -645,32 +645,31 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
 
             // parse expressions {{somevar + 2}}
             // We only support single expressions for now
-            //auto ESCAPE_SKIP = std::basic_string("\\");
             while (RHS.contains("{{")) {
                 auto firstUnescaped = RHS.find("{{");
-                //keep searching until non escaped expression start is found
-                while(firstUnescaped > 0){
-                    //special check to avoid undefined behaviour with std::basic_string::find_last_not_of
+                // Keep searching until non-escaped expression start is found
+                while (firstUnescaped > 0) {
+                    // Special check to avoid undefined behaviour with std::basic_string::find_last_not_of
                     auto amountSkipped = 0;
-                    for(int i = firstUnescaped - 1; i >= 0; i--){
-                        if(RHS.at(i) != '\\')
+                    for (int i = firstUnescaped - 1; i >= 0; i--) {
+                        if (RHS.at(i) != '\\')
                             break;
                         amountSkipped++;
                     }
-                    // no escape chars, or even escape chars. means they escaped themselves.
+                    // No escape chars, or even escape chars. means they escaped themselves.
                     if (amountSkipped % 2 == 0)
                         break;
-                    // continue searching for next valid expression start.
+                    // Continue searching for next valid expression start.
                     firstUnescaped = RHS.find("{{", firstUnescaped + 1);
-                    //break if the next match is never found
-                    if(firstUnescaped == std::string::npos) 
+                    // Break if the next match is never found
+                    if (firstUnescaped == std::string::npos) 
                         break;
                 }
-                //real match was never found.
-                if(firstUnescaped == std::string::npos)
+                // Real match was never found.
+                if (firstUnescaped == std::string::npos)
                     break;
                 const auto BEGIN_EXPR = firstUnescaped;
-                // }} doesnt need escaping. Would be invalid expression anyways.
+                // "}}" doesnt need escaping. Would be invalid expression anyways.
                 const auto END_EXPR   = RHS.find("}}", BEGIN_EXPR + 2);
                 if (END_EXPR != std::string::npos) {
                     // try to parse the expression
@@ -702,17 +701,17 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
         // Right now only expression parsing has escapeable chars
         const char ESCAPE_CHAR = '\\';
         const char ESCAPE_SET[]{'{','}'};
-        for (long i = 0; i < (long)RHS.length() - (long)1; i++){
+        for (long i = 0; i < (long)RHS.length() - (long)1; i++) {
             if (RHS.at(i) != ESCAPE_CHAR)
                 continue;
             //if escaping an escape, remove and skip the next char
-            if (RHS.at(i + 1) == ESCAPE_CHAR){
+            if (RHS.at(i + 1) == ESCAPE_CHAR) {
                 RHS.erase(i,1);
                 continue;
             }
             //checks if any of the chars were escapable.
-            for(unsigned int j = 0; j < sizeof(ESCAPE_SET) / sizeof(char); j++){
-                if(RHS.at(i+1) == ESCAPE_SET[j]){
+            for (unsigned int j = 0; j < sizeof(ESCAPE_SET) / sizeof(char); j++) {
+                if (RHS.at(i+1) == ESCAPE_SET[j]) {
                     RHS.erase(i--,1);
                     break;
                 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -647,16 +647,15 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
             while (RHS.contains("{{")) {
                 auto firstUnescaped = RHS.find("{{");
                 //keep searching until the escape char is not found.
-                while(RHS.at(firstUnescaped - 1) == '\\'){
+                while(firstUnescaped != 0 && RHS.at(firstUnescaped - 1) == '\\'){
                     firstUnescaped = RHS.find("{{", firstUnescaped + 1);
                     //break if the next match is never found
                     if(firstUnescaped == std::string::npos) 
                         break;
                 }
                 //real match was never found.
-                if(firstUnescaped == std::string::npos){
+                if(firstUnescaped == std::string::npos)
                     break;
-                } 
                 const auto BEGIN_EXPR = firstUnescaped;
                 // }} doesnt need escaping. Would be invalid expression anyways.
                 const auto END_EXPR   = RHS.find("}}", BEGIN_EXPR + 2);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -710,8 +710,8 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                 continue;
             }
             //checks if any of the chars were escapable.
-            for (size_t j = 0; j < ESCAPE_SET.size(); j++) {
-                if (RHS.at(i + 1) != ESCAPE_SET[j])
+            for (const auto& ESCAPABLE_CHAR : ESCAPE_SET) {
+                if (RHS.at(i + 1) != ESCAPABLE_CHAR)
                     continue;
                 RHS.erase(i--, 1);
                 break;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -642,14 +642,14 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                 anyMatch = true;
             }
 
-            // parse expressions $(somevar + 2)
+            // parse expressions {{somevar + 2}}
             // We only support single expressions for now
             while (RHS.contains("{{")) {
                 auto firstUnescaped = RHS.find("{{");
                 //keep searching until the escape char is not found.
                 while(RHS.at(firstUnescaped - 1) == '\\'){
                     firstUnescaped = RHS.find("{{", firstUnescaped + 1);
-                    //escape if the next match is never found
+                    //break if the next match is never found
                     if(firstUnescaped == std::string::npos) 
                         break;
                 }
@@ -658,7 +658,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                     break;
                 } 
                 const auto BEGIN_EXPR = firstUnescaped;
-                // }} doesnt need escaping. it would be valid if escaped anyways.
+                // }} doesnt need escaping. Would be invalid expression anyways.
                 const auto END_EXPR   = RHS.find("}}", BEGIN_EXPR + 2);
                 if (END_EXPR != std::string::npos) {
                     // try to parse the expression

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -662,7 +662,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                     // Continue searching for next valid expression start.
                     firstUnescaped = RHS.find("{{", firstUnescaped + 1);
                     // Break if the next match is never found
-                    if (firstUnescaped == std::string::npos) 
+                    if (firstUnescaped == std::string::npos)
                         break;
                 }
                 // Real match was never found.
@@ -670,7 +670,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                     break;
                 const auto BEGIN_EXPR = firstUnescaped;
                 // "}}" doesnt need escaping. Would be invalid expression anyways.
-                const auto END_EXPR   = RHS.find("}}", BEGIN_EXPR + 2);
+                const auto END_EXPR = RHS.find("}}", BEGIN_EXPR + 2);
                 if (END_EXPR != std::string::npos) {
                     // try to parse the expression
                     const auto RESULT = impl->parseExpression(RHS.substr(BEGIN_EXPR + 2, END_EXPR - BEGIN_EXPR - 2));
@@ -693,26 +693,25 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
             }
         }
 
-
         if (ISVARIABLE)
             return parseVariable(LHS, RHS, dynamic);
 
         // Removing escape chars. -- in the future, maybe map all the chars that can be escaped.
         // Right now only expression parsing has escapeable chars
         const char ESCAPE_CHAR = '\\';
-        const char ESCAPE_SET[]{'{','}'};
+        const char ESCAPE_SET[]{'{', '}'};
         for (long i = 0; i < (long)RHS.length() - (long)1; i++) {
             if (RHS.at(i) != ESCAPE_CHAR)
                 continue;
             //if escaping an escape, remove and skip the next char
             if (RHS.at(i + 1) == ESCAPE_CHAR) {
-                RHS.erase(i,1);
+                RHS.erase(i, 1);
                 continue;
             }
             //checks if any of the chars were escapable.
             for (unsigned int j = 0; j < sizeof(ESCAPE_SET) / sizeof(char); j++) {
-                if (RHS.at(i+1) == ESCAPE_SET[j]) {
-                    RHS.erase(i--,1);
+                if (RHS.at(i + 1) == ESCAPE_SET[j]) {
+                    RHS.erase(i--, 1);
                     break;
                 }
             }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -701,7 +701,7 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
         // Right now only expression parsing has escapeable chars
         const char                ESCAPE_CHAR = '\\';
         const std::array<char, 2> ESCAPE_SET{'{', '}'};
-        for (long i = 0; i < (long)RHS.length() - (long)1; i++) {
+        for (size_t i = 0; RHS.length() != 0 && i < RHS.length() - 1; i++) {
             if (RHS.at(i) != ESCAPE_CHAR)
                 continue;
             //if escaping an escape, remove and skip the next char
@@ -710,11 +710,11 @@ CParseResult CConfig::parseLine(std::string line, bool dynamic) {
                 continue;
             }
             //checks if any of the chars were escapable.
-            for (unsigned int j = 0; j < ESCAPE_SET.size(); j++) {
-                if (RHS.at(i + 1) == ESCAPE_SET[j]) {
-                    RHS.erase(i--, 1);
-                    break;
-                }
+            for (size_t j = 0; j < ESCAPE_SET.size(); j++) {
+                if (RHS.at(i + 1) != ESCAPE_SET[j])
+                    continue;
+                RHS.erase(i--, 1);
+                break;
             }
         }
 

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -29,7 +29,7 @@ testImbeddedEscapedExpression = $ESCAPED_TEXT
 
 $MOVING_VAR = 1000
 $DYNAMIC_EXPRESSION = moved: {{$MOVING_VAR / 2}} expr: \{{$MOVING_VAR / 2}}
-testDynamicEscapedExpression = \{{ $DYMAMIC_EXPRESSION }}
+testDynamicEscapedExpression = \{{ $DYNAMIC_EXPRESSION }}
 
 testEnv = $SHELL
 

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -17,6 +17,20 @@ testVar = $MY_VAR$MY_VAR_2
 $EXPR_VAR = {{MY_VAR + 2}}
 testExpr = {{EXPR_VAR - 4}}
 
+testEscapedExpr = \{{testInt + 7}}
+testEscapedExpr2 = {\{testInt + 7}}
+testEscapedExpr3 = \{\{3 + 8}}
+testEscapedEscape = \\{{10 - 5}}
+testMixedEscapedExpression = {{8 - 10}} \{{ \{{50+50}} / \{{10 * 5}} }} 
+testMixedEscapedExpression2 = {\{8\\{{10+3}}}} should equal "\{{8\13}}"
+
+$ESCAPED_TEXT = \{{10 + 10}}
+testImbeddedEscapedExpression = $ESCAPED_TEXT
+
+$MOVING_VAR = 1000
+$DYNAMIC_EXPRESSION = moved: {{$MOVING_VAR / 2}} expr: \{{$MOVING_VAR / 2}}
+testDynamicEscapedExpression = \{{ $DYMAMIC_EXPRESSION }}
+
 testEnv = $SHELL
 
 source = ./colors.conf

--- a/tests/config/config.conf
+++ b/tests/config/config.conf
@@ -21,8 +21,8 @@ testEscapedExpr = \{{testInt + 7}}
 testEscapedExpr2 = {\{testInt + 7}}
 testEscapedExpr3 = \{\{3 + 8}}
 testEscapedEscape = \\{{10 - 5}}
-testMixedEscapedExpression = {{8 - 10}} \{{ \{{50+50}} / \{{10 * 5}} }} 
-testMixedEscapedExpression2 = {\{8\\{{10+3}}}} should equal "\{{8\13}}"
+testMixedEscapedExpression = {{8 - 10}} \{{ \{{50 + 50}} / \{{10 * 5}} }} 
+testMixedEscapedExpression2 = {\{8\\{{10 + 3}}}} should equal "\{{8\13}}"
 
 $ESCAPED_TEXT = \{{10 + 10}}
 testImbeddedEscapedExpression = $ESCAPED_TEXT

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -216,7 +216,7 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testEscapedExpr2")), std::string{"{{testInt + 7}}"});
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testEscapedExpr3")), std::string{"{{3 + 8}}"});
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testEscapedEscape")), std::string{"\\5"});
-        EXPECT(std::any_cast<const char*>(config.getConfigValue("testMixedEscapedExpression")), std::string{"2 {{ {{50+50}} / {{10 * 5}} }}"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testMixedEscapedExpression")), std::string{"-2 {{ {{50 + 50}} / {{10 * 5}} }}"});
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testMixedEscapedExpression2")), std::string{"{{8\\13}} should equal \"{{8\\13}}\""});
 
 

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -108,6 +108,14 @@ int main(int argc, char** argv, char** envp) {
         // setup config
         config.addConfigValue("testInt", (Hyprlang::INT)0);
         config.addConfigValue("testExpr", (Hyprlang::INT)0);
+        config.addConfigValue("testEscapedExpr", "");
+        config.addConfigValue("testEscapedExpr2", "");
+        config.addConfigValue("testEscapedExpr3", "");
+        config.addConfigValue("testEscapedEscape", "");
+        config.addConfigValue("testMixedEscapedExpression", "");
+        config.addConfigValue("testMixedEscapedExpression2", "");
+        config.addConfigValue("testImbeddedEscapedExpression", "");
+        config.addConfigValue("testDynamicEscapedExpression", "");
         config.addConfigValue("testFloat", 0.F);
         config.addConfigValue("testVec", Hyprlang::SVector2D{.x = 69, .y = 420});
         config.addConfigValue("testString", "");
@@ -202,6 +210,20 @@ int main(int argc, char** argv, char** envp) {
         std::cout << " → Testing expressions\n";
         EXPECT(std::any_cast<int64_t>(config.getConfigValue("testExpr")), 1335);
 
+        // test expression escape
+        std::cout << " → Testing expression escapes\n";
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testEscapedExpr")), std::string{"{{testInt + 7}}"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testEscapedExpr2")), std::string{"{{testInt + 7}}"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testEscapedExpr3")), std::string{"{{3 + 8}}"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testEscapedEscape")), std::string{"\\5"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testMixedEscapedExpression")), std::string{"2 {{ {{50+50}} / {{10 * 5}} }}"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testMixedEscapedExpression2")), std::string{"{{8\\13}} should equal \"{{8\\13}}\""});
+
+
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testImbeddedEscapedExpression")), std::string{"{{10 + 10}}"});
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testDynamicEscapedExpression")), std::string{"{{ moved: 500 expr: {{1000 / 2}} }}"});
+
+
         // test static values
         std::cout << " → Testing static values\n";
         static auto* const PTESTINT = config.getConfigValuePtr("testInt")->getDataStaticPtr();
@@ -247,6 +269,10 @@ int main(int argc, char** argv, char** envp) {
 
         EXPECT(config.parseDynamic("$RECURSIVE1 = d").error, false);
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testStringRecursive")), std::string{"dbc"});
+
+        // test expression escape with dynamic vars
+        EXPECT(config.parseDynamic("$MOVING_VAR = 500").error, false);
+        EXPECT(std::any_cast<const char*>(config.getConfigValue("testDynamicEscapedExpression")), std::string{"{{ moved: 250 expr: {{500 / 2}} }}"});
 
         // test dynamic exprs
         EXPECT(config.parseDynamic("testExpr = {{EXPR_VAR * 2}}").error, false);

--- a/tests/parse/main.cpp
+++ b/tests/parse/main.cpp
@@ -219,10 +219,8 @@ int main(int argc, char** argv, char** envp) {
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testMixedEscapedExpression")), std::string{"-2 {{ {{50 + 50}} / {{10 * 5}} }}"});
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testMixedEscapedExpression2")), std::string{"{{8\\13}} should equal \"{{8\\13}}\""});
 
-
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testImbeddedEscapedExpression")), std::string{"{{10 + 10}}"});
         EXPECT(std::any_cast<const char*>(config.getConfigValue("testDynamicEscapedExpression")), std::string{"{{ moved: 500 expr: {{1000 / 2}} }}"});
-
 
         // test static values
         std::cout << " → Testing static values\n";


### PR DESCRIPTION
This is to solve this [issue](https://github.com/hyprwm/hyprlang/issues/75). On the 0.6.3 hyprlang release, the ability to do simple arithmetics were added with the {{VAL1 <+,-,*,/> VAL2}} syntax. 
The only issue is that this is un-escapable, so in simple binds or commands that use this syntax, most notably the playerctl's formatted output.

To add the ability to escape this syntax, I simply added the ability to add '\' to multiple parts of the expression.
`\{{   {\{   \{\{` will all escape from the arithmetic expression. This also works for "}" but theres no point in doing so.

I have tested this on my main configuration and on a simple config with this:
`exec=hyprctl notify 5000 50000 'rgb(ffffff)' "{{1 + 2}} {\{test}} {\{20 - 10}} \{\{10 + 10}} \}} \}\} {{ \{{ \\{{"`
with this output in the message:
`3 {{test}} {{20 - 10}} {{10 + 10}} }} }} {{ {{ \{{`