### PR TITLE
Update wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ add_baker = Koichi, 18, Morioh
 
 ## Docs
 
-Visit [hyprland.org/hyprlang](https://hyprland.org/hyprlang) to see the documentation.
+Visit [wiki.hypr.land/Hypr-Ecosystem/hyprlang/](https://wiki.hypr.land/Hypr-Ecosystem/hyprlang/) to see the documentation.
 
 ### Example implementation
 


### PR DESCRIPTION
the old wiki link is no longer valid

this link seems a little verbose, not sure if a server side different link might make sense too, either way it should move to hypr.land instead of hyprland.org